### PR TITLE
Fix bug in inception module

### DIFF
--- a/python/ch11/11.3.2-inception.ipynb
+++ b/python/ch11/11.3.2-inception.ipynb
@@ -167,7 +167,7 @@
     "        # 5x5 branch\n",
     "        # 1x1 conv\n",
     "        self.branch5x5_1 = torch.nn.Sequential(\n",
-    "                        nn.Conv2d(in_channels, reduce_5x5, kernel_size=5, padding=2, bias=False),\n",
+    "                        nn.Conv2d(in_channels, reduce_5x5, kernel_size=1, bias=False),\n",
     "                        nn.BatchNorm2d(reduce_5x5, eps=0.001),\n",
     "                        nn.ReLU(inplace=True))\n",
     "        self.branch5x5_2 = torch.nn.Sequential(\n",
@@ -202,7 +202,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of parameters: 275680\n"
+      "Number of parameters: 177376\n"
      ]
     }
    ],
@@ -247,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes error in implementation of Inceptionv1Module. The code was using a 5x5 kernel instead of a 1x1 conv to reduce dimensionsionality.